### PR TITLE
Fix https://github.com/HaxeFlixel/flixel-demos/issues/236 by passing …

### DIFF
--- a/flixel/addons/ui/FlxUITooltipManager.hx
+++ b/flixel/addons/ui/FlxUITooltipManager.hx
@@ -583,7 +583,7 @@ class FlxUITooltipManager implements IFlxDestroyable
 			{
 				anchor = tooltip.anchor;
 			}
-			anchor = anchor.getFlipped(flipX, flipY);
+			anchor.getFlipped(flipX, flipY, anchor);
 			return true;
 		}
 		


### PR DESCRIPTION
…anchor to be modified, instead of making a new one and having it evaporate upon function return.
