### PR TITLE
Add a function so you can set tooltip cameras.  If you are using some…

### DIFF
--- a/flixel/addons/ui/FlxUITooltipManager.hx
+++ b/flixel/addons/ui/FlxUITooltipManager.hx
@@ -1,4 +1,5 @@
 package flixel.addons.ui;
+import flixel.FlxCamera;
 import flixel.addons.ui.FlxUITooltip;
 import flixel.addons.ui.interfaces.IFlxUIButton;
 import flixel.addons.ui.interfaces.IFlxUIState;
@@ -38,6 +39,7 @@ class FlxUITooltipManager implements IFlxDestroyable
 	public var showOnClick:Bool = false;
 	public var delay:Float = 0.1;
 	public var showTooltipArrow(default, set):Bool;
+	public var cameras(default, set):Array<FlxCamera>;
 	
 	public function new(?State:FlxUIState,?SubState:FlxUISubState) 
 	{
@@ -588,6 +590,12 @@ class FlxUITooltipManager implements IFlxDestroyable
 		}
 		
 		return false;
+	}
+	
+	function set_cameras(value:Array<FlxCamera>):Array<FlxCamera> 
+	{
+		tooltip.cameras = value;
+		return cameras = value;
 	}
 }
 


### PR DESCRIPTION
… custom cameras that would normally appear in front of your tooltips, this allows you enough control to fix them so they're not longer hidden.
